### PR TITLE
Cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 88
+exclude = .venv
 
 [metadata]
 license_files = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ disallow_incomplete_defs = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
-junit_xml = typing-coverage.xml
 no_implicit_optional = True
 pretty = True
 warn_redundant_casts = True


### PR DESCRIPTION
- Stop creating unused `typing-coverage.xml`
- Do not lint `.venv` directory